### PR TITLE
Changed Contrast YAML mount directory

### DIFF
--- a/java/init_container/overlays/contrast/contrast-java-agent.yaml
+++ b/java/init_container/overlays/contrast/contrast-java-agent.yaml
@@ -11,11 +11,11 @@ spec:
             - name: contrast-agent-src
               mountPath: /opt/contrast
             - name: contrast-security
-              mountPath: /root/contrast_security.yaml
+              mountPath: /opt/contrast/contrast_security.yaml
               subPath: contrast_security.yaml
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: -javaagent:/opt/contrast/contrast-agent.jar -Dcontrast.config.path=/root/contrast_security.yaml
+              value: -javaagent:/opt/contrast/contrast-agent.jar -Dcontrast.config.path=/opt/contrast/contrast_security.yaml
       initContainers:
         - name: init-contrast-agent
           image: contrast/java-agent:3.8.7.21531


### PR DESCRIPTION
Modified directory from /root to /opt/contrast directory because image permissions can restrict access to the /root directory in the image and agent won't start.